### PR TITLE
Fixed number of parameter isuue for fuction: async_pipeline_from_audi…

### DIFF
--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -14,9 +14,11 @@ from homeassistant.components import media_source, stt, tts
 from homeassistant.components.assist_pipeline import (
     OPTION_PREFERRED,
     AudioSettings,
+    PipelineConfig,
     PipelineEvent,
     PipelineEventType,
     PipelineStage,
+    WakeWordConfig,
     async_get_pipeline,
     async_get_pipelines,
     async_pipeline_from_audio_stream,
@@ -308,6 +310,22 @@ class AssistSatelliteEntity(entity.Entity):
             self._conversation_id = None
             self._conversation_id_time = None
 
+        wake_word_config = WakeWordConfig(
+            wake_word_phrase=wake_word_phrase,
+        )
+
+        pipeline_config = PipelineConfig(
+            pipeline_id=self._resolve_pipeline(),
+            conversation_id=self._conversation_id,
+            tts_audio_output=self.tts_options,
+            audio_settings=AudioSettings(
+                silence_seconds=self._resolve_vad_sensitivity()
+            ),
+            device_id=device_id,
+            start_stage=start_stage,
+            end_stage=end_stage,
+        )
+
         # Set entity state based on pipeline events
         self._run_has_tts = False
 
@@ -327,16 +345,8 @@ class AssistSatelliteEntity(entity.Entity):
                     channel=stt.AudioChannels.CHANNEL_MONO,
                 ),
                 stt_stream=audio_stream,
-                pipeline_id=self._resolve_pipeline(),
-                conversation_id=self._conversation_id,
-                device_id=device_id,
-                tts_audio_output=self.tts_options,
-                wake_word_phrase=wake_word_phrase,
-                audio_settings=AudioSettings(
-                    silence_seconds=self._resolve_vad_sensitivity()
-                ),
-                start_stage=start_stage,
-                end_stage=end_stage,
+                wake_word_config=wake_word_config,
+                pipeline_config=pipeline_config,
             ),
             f"{self.entity_id}_pipeline",
         )


### PR DESCRIPTION
## Fix the too many parameter issue for the function async_pipeline_from_audio_stream

#### Changes: 
- Created two dataclasses that capture parameters that seem to be related (WakeWordConfig and PipelineConfig).
- Changed all the calls to this function to reflect the changes.

#### Tested:
- Ran Sonarqube once the changes had been made - The issue was no longer present, however the quality gate for new code now fails due to line coverage and duplicated code in tests which I duplicated intentionally to keep tests independent and isolated.
- Ran the particular test file that related to this function - All tests pass, as shown below. 

![Capture](https://github.com/user-attachments/assets/1406a723-fadf-4eb4-b162-e6446aa014bf)
