### PR TITLE
Fix 'Cognitive Complexity of functions should not be too high' of the vad.py process function

### DIFF
--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -124,6 +124,26 @@ class VoiceCommandSegmenter:
         self._reset_seconds_left = self.reset_seconds
         self.in_command = False
 
+    def _process_not_in_command(
+        self, is_speech: bool | None, chunk_seconds: float
+    ) -> None:
+        """Process samples when not in a voice command."""
+        if is_speech:
+            self._reset_seconds_left = self.reset_seconds
+            self._speech_seconds_left -= chunk_seconds
+            if self._speech_seconds_left <= 0:
+                # Inside voice command
+                self.in_command = True
+                self._command_seconds_left = self.command_seconds - self.speech_seconds
+                self._silence_seconds_left = self.silence_seconds
+                _LOGGER.debug("Voice command started")
+        else:
+            # Reset if enough silence
+            self._reset_seconds_left -= chunk_seconds
+            if self._reset_seconds_left <= 0:
+                self._speech_seconds_left = self.speech_seconds
+                self._reset_seconds_left = self.reset_seconds
+
     def process(self, chunk_seconds: float, is_speech: bool | None) -> bool:
         """Process samples using external VAD.
 
@@ -143,23 +163,7 @@ class VoiceCommandSegmenter:
             return False
 
         if not self.in_command:
-            if is_speech:
-                self._reset_seconds_left = self.reset_seconds
-                self._speech_seconds_left -= chunk_seconds
-                if self._speech_seconds_left <= 0:
-                    # Inside voice command
-                    self.in_command = True
-                    self._command_seconds_left = (
-                        self.command_seconds - self.speech_seconds
-                    )
-                    self._silence_seconds_left = self.silence_seconds
-                    _LOGGER.debug("Voice command started")
-            else:
-                # Reset if enough silence
-                self._reset_seconds_left -= chunk_seconds
-                if self._reset_seconds_left <= 0:
-                    self._speech_seconds_left = self.speech_seconds
-                    self._reset_seconds_left = self.reset_seconds
+            self._process_not_in_command(is_speech, chunk_seconds)
         elif not is_speech:
             # Silence in command
             self._reset_seconds_left = self.reset_seconds


### PR DESCRIPTION
## Fix the cognitive complexity issue for the 'process' function

#### Changes: 
- Created a separate function to handle the 'not in command' situation of the process function.
- Call the created function from the process function.

#### Tested:
- Ran Sonarqube after the change was made: The congitive complexity issue was resolved. 
- Ran the vad.py test file which passes after the changes were made.

![image](https://github.com/user-attachments/assets/44fb2a60-c0cc-453d-bfcd-a3ac3bf76766)

