### PR TITLE
Fix 'Define a constant instead of duplicating this literal (mdi:gauge)' issue of the buienradar sensor.py file

### DIFF
--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -72,6 +72,8 @@ SCHEDULE_NOK = 2
 
 STATIONNAME_LABEL = "Stationname"
 
+GAUGE_ICON = "mdi:gauge"
+
 SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="stationname",
@@ -81,19 +83,19 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="barometerfc",
         translation_key="barometerfc",
-        icon="mdi:gauge",
+        icon=GAUGE_ICON,
     ),
     # new in json api (>1.0.0):
     SensorEntityDescription(
         key="barometerfcname",
         translation_key="barometerfcname",
-        icon="mdi:gauge",
+        icon=GAUGE_ICON,
     ),
     # new in json api (>1.0.0):
     SensorEntityDescription(
         key="barometerfcnamenl",
         translation_key="barometerfcnamenl",
-        icon="mdi:gauge",
+        icon=GAUGE_ICON,
     ),
     SensorEntityDescription(
         key="condition",
@@ -175,7 +177,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="pressure",
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=UnitOfPressure.HPA,
-        icon="mdi:gauge",
+        icon=GAUGE_ICON,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(


### PR DESCRIPTION
## Fix the duplicate literal issue for the 'sensor.py' file

#### Changes: 
- Replace literal constants for 'mdi:gauge' with a constant

#### Tested:
- Ran Sonarqube after the change was made: The congitive complexity issue was resolved. 
- Ran the test_sensor test file which passes after the changes were made.

![image](https://github.com/user-attachments/assets/8792d601-092a-48ef-ad1c-c1fc80ae165a)


