### PR TITLE
Fix 'Define a constant instead of duplicating this literal (mdi:weather-windy)' issue of the buienradar sensor.py file

### DIFF
--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -65,6 +65,8 @@ MEASURED_LABEL = "Measured"
 TIMEFRAME_LABEL = "Timeframe"
 SYMBOL = "symbol"
 
+WEATHER_WINDY_ICON = "mdi:weather-windy"
+
 # Schedule next call after (minutes):
 SCHEDULE_OK = 10
 # When an error occurred, new call after (minutes):
@@ -158,7 +160,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="windforce",
         translation_key="windforce",
         native_unit_of_measurement="Bft",
-        icon="mdi:weather-windy",
+        icon=WEATHER_WINDY_ICON,
     ),
     SensorEntityDescription(
         key="winddirection",
@@ -445,31 +447,31 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="windforce_1d",
         translation_key="windforce_1d",
         native_unit_of_measurement="Bft",
-        icon="mdi:weather-windy",
+        icon=WEATHER_WINDY_ICON,
     ),
     SensorEntityDescription(
         key="windforce_2d",
         translation_key="windforce_2d",
         native_unit_of_measurement="Bft",
-        icon="mdi:weather-windy",
+        icon=WEATHER_WINDY_ICON,
     ),
     SensorEntityDescription(
         key="windforce_3d",
         translation_key="windforce_3d",
         native_unit_of_measurement="Bft",
-        icon="mdi:weather-windy",
+        icon=WEATHER_WINDY_ICON,
     ),
     SensorEntityDescription(
         key="windforce_4d",
         translation_key="windforce_4d",
         native_unit_of_measurement="Bft",
-        icon="mdi:weather-windy",
+        icon=WEATHER_WINDY_ICON,
     ),
     SensorEntityDescription(
         key="windforce_5d",
         translation_key="windforce_5d",
         native_unit_of_measurement="Bft",
-        icon="mdi:weather-windy",
+        icon=WEATHER_WINDY_ICON,
     ),
     SensorEntityDescription(
         key="windspeed_1d",


### PR DESCRIPTION
## Fix the duplicate literal issue for the 'sensor.py' file

#### Changes: 
- Replace literal constants for 'mdi:weather-windy' with a constant

#### Tested:
- Ran Sonarqube after the change was made: The congitive complexity issue was resolved. 
- Ran the test_sensor test file which passes after the changes were made.
![image](https://github.com/user-attachments/assets/1763acb1-c3bf-49a6-ae8b-b5ae017a1a0f)



