### PR TITLE
Fix 'Define a constant instead of duplicating this literal (mdi:weather-pouring)' issue of the buienradar sensor.py file 

### DIFF
--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -65,6 +65,8 @@ MEASURED_LABEL = "Measured"
 TIMEFRAME_LABEL = "Timeframe"
 SYMBOL = "symbol"
 
+WEATHER_POURING_ICON = "mdi:weather-pouring"
+
 # Schedule next call after (minutes):
 SCHEDULE_OK = 10
 # When an error occurred, new call after (minutes):
@@ -385,31 +387,31 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="rainchance_1d",
         translation_key="rainchance_1d",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-pouring",
+        icon=WEATHER_POURING_ICON,
     ),
     SensorEntityDescription(
         key="rainchance_2d",
         translation_key="rainchance_2d",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-pouring",
+        icon=WEATHER_POURING_ICON,
     ),
     SensorEntityDescription(
         key="rainchance_3d",
         translation_key="rainchance_3d",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-pouring",
+        icon=WEATHER_POURING_ICON,
     ),
     SensorEntityDescription(
         key="rainchance_4d",
         translation_key="rainchance_4d",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-pouring",
+        icon=WEATHER_POURING_ICON,
     ),
     SensorEntityDescription(
         key="rainchance_5d",
         translation_key="rainchance_5d",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-pouring",
+        icon=WEATHER_POURING_ICON,
     ),
     SensorEntityDescription(
         key="sunchance_1d",


### PR DESCRIPTION
## Fix the duplicate literal issue for the 'sensor.py' file

#### Changes: 
- Replace literal constants for 'mdi:weather-pouring' with a constant

#### Tested:
- Ran Sonarqube after the change was made: The congitive complexity issue was resolved. 
- Ran the test_sensor test file which passes after the changes were made.
![image](https://github.com/user-attachments/assets/f9ce5fff-0a22-4f68-afda-cc0957cbd499)

