### PR TITLE
Fixed Alexa handlers.py - duplicating of a literal "Alexa.SecurityPanelController"

### DIFF
--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -84,6 +84,7 @@ from .state_report import AlexaDirective, AlexaResponse, async_enable_proactive_
 
 _LOGGER = logging.getLogger(__name__)
 DIRECTIVE_NOT_SUPPORTED = "Entity does not support directive"
+SECURITY_PANEL_CONTROLLER = "Alexa.SecurityPanelController"
 
 MIN_MAX_TEMP = {
     climate.DOMAIN: {
@@ -1070,7 +1071,7 @@ async def async_api_reportstate(
     return directive.response(name="StateReport")
 
 
-@HANDLERS.register(("Alexa.SecurityPanelController", "Arm"))
+@HANDLERS.register((SECURITY_PANEL_CONTROLLER, "Arm"))
 async def async_api_arm(
     hass: ha.HomeAssistant,
     config: AbstractConfig,
@@ -1104,13 +1105,13 @@ async def async_api_arm(
     payload: dict[str, Any] = {"exitDelayInSeconds": 0}
 
     response = directive.response(
-        name="Arm.Response", namespace="Alexa.SecurityPanelController", payload=payload
+        name="Arm.Response", namespace=SECURITY_PANEL_CONTROLLER, payload=payload
     )
 
     response.add_context_property(
         {
             "name": "armState",
-            "namespace": "Alexa.SecurityPanelController",
+            "namespace": SECURITY_PANEL_CONTROLLER,
             "value": arm_state,
         }
     )
@@ -1118,7 +1119,7 @@ async def async_api_arm(
     return response
 
 
-@HANDLERS.register(("Alexa.SecurityPanelController", "Disarm"))
+@HANDLERS.register((SECURITY_PANEL_CONTROLLER, "Disarm"))
 async def async_api_disarm(
     hass: ha.HomeAssistant,
     config: AbstractConfig,
@@ -1149,7 +1150,7 @@ async def async_api_disarm(
     response.add_context_property(
         {
             "name": "armState",
-            "namespace": "Alexa.SecurityPanelController",
+            "namespace": SECURITY_PANEL_CONTROLLER,
             "value": "DISARMED",
         }
     )


### PR DESCRIPTION
Sonarqube code smell - Define a constant instead of duplicating this literal "Alexa.SecurityPanelController" 3 times.

Changes:
Defined a constant for the value "Alexa.SecurityPanelController" and replaced the values in the file.
Tested:
Ran Sonarqube after the change. The issue was no longer present.

Note - There is no test file available for Alexa Handlers